### PR TITLE
Use per-job temp dirs and cleanup files

### DIFF
--- a/backend/services/audio/audio_generator.py
+++ b/backend/services/audio/audio_generator.py
@@ -8,9 +8,9 @@ from core.constants import EL_MATILDA_VOICE_ID
 
 
 class AudioGenerator:
-    def __init__(self):
+    def __init__(self, temp_dir: str | None = None):
         self.logger = logging.getLogger("vidgenai.audio_generator")
-        self.temp_dir = tempfile.gettempdir()
+        self.temp_dir = temp_dir or tempfile.gettempdir()
 
     async def _generate_with_eleven_labs(self, script: str, audio_filename: str) -> str:
         try:

--- a/backend/services/subtitles/subtitle_generator.py
+++ b/backend/services/subtitles/subtitle_generator.py
@@ -121,8 +121,8 @@ class SubtitleGenerator:
             GroqTranscriptionProvider()
         ]
 
-    async def generate(self, script: str, audio_path: str) -> str:
-        temp_dir = tempfile.gettempdir()
+    async def generate(self, script: str, audio_path: str, temp_dir: str | None = None) -> str:
+        temp_dir = temp_dir or tempfile.gettempdir()
         subtitle_filename = os.path.join(
             temp_dir, f"subtitles_{os.path.basename(audio_path)}.srt"
         )


### PR DESCRIPTION
## Summary
- generate a dedicated temporary directory for each job
- pass the job's temp dir to audio, subtitle and video steps
- delete the entire temp directory at the end of a job

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684287540c2883268b629061c630138c